### PR TITLE
Add options to specify images via DPA unsupported overrides

### DIFF
--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -7,8 +7,43 @@ spec:
   backupImages: false
   unsupportedOverrides:
     operator-type: mtc
+{% if oadp_velero_image_fqin is defined %}
+    veleroImageFqin: "{{ oadp_velero_image_fqin }}"
+{% else %}
+    veleroImageFqin: null
+{% endif %}
+{% if oadp_openshift_plugin_fqin is defined %}
+    openshiftPluginImageFqin: "{{ oadp_openshift_plugin_fqin }}"
+{% else %}
+    openshiftPluginImageFqin: null
+{% endif %}
+{% if oadp_restic_restore_helper_fqin is defined %}
+    resticRestoreImageFqin: "{{ oadp_restic_restore_helper_fqin }}"
+{% else %}
+    resticRestoreImageFqin: null
+{% endif %}
+{% if oadp_aws_plugin_fqin is defined %}
+    awsPluginImageFqin: "{{ oadp_aws_plugin_fqin }}"
+{% else %}
+    awsPluginImageFqin: null
+{% endif %}
+{% if oadp_azure_plugin_fqin is defined %}
+    azurePluginImageFqin: "{{ oadp_azure_plugin_fqin }}"
+{% else %}
+    azurePluginImageFqin: null
+{% endif %}
+{% if oadp_gcp_plugin_fqin is defined %}
+    gcpPluginImageFqin: "{{ oadp_gcp_plugin_fqin }}"
+{% else %}
+    gcpPluginImageFqin: null
+{% endif %}
   configuration:
     velero:
+{% if velero_log_level is defined %}
+      logLevel: "{{ velero_log_level }}"
+{% else %}
+      logLevel: null
+{% endif %}
       defaultPlugins:
       - openshift
       - aws


### PR DESCRIPTION
Added options do not use previous `velero_` variables, instead they introduce their own variables with `oadp_`. This is because `velero_` options are always initialized and that makes DPA CR to have unsupportedOverrides all the time. The new options are not initialized.  