### PR TITLE
Add RBAC to manipulate VMI and VMIM

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v99.0.0.clusterserviceversion.yaml
@@ -368,6 +368,15 @@ spec:
           - list
           - get
           - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - 'virtualmachineinstances'
+          - 'virtualmachineinstancemigrations'
+          verbs:
+          - list
+          - get
+          - watch
       - serviceAccountName: migration-controller
         rules:
         - apiGroups:
@@ -617,6 +626,15 @@ spec:
           - 'VirtualMachines'
           verbs:
           - update
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - kubevirt.io
+          resources:
+          - 'virtualmachineinstances'
+          - 'virtualmachineinstancemigrations'
+          verbs:
           - list
           - get
           - watch


### PR DESCRIPTION
In order to support storage live migration we need to be able to get/list the VMI and VMIM objects.