### PR TITLE
Add owner type to MigPlan CRD

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migplans.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migplans.yaml
@@ -390,6 +390,8 @@ spec:
                           type: string
                         namespace:
                           type: string
+                        ownerType:
+                          type: string
                         volumeMode:
                           description: PersistentVolumeMode describes how a volume
                             is intended to be consumed, either Block or Filesystem.


### PR DESCRIPTION
Adding owner type allows the UI to customize the view based on the owner of the PV. This is helpful with allowing the user to select which volumeMode or accessMode to pick. For instance VirtualMachines can be migrated between different combinations while things like ReplicaSets cannot.